### PR TITLE
Link to docs.rs

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ beanstalkd = "*"
 
 ## Documentation
 
-More documentation can be found [here](http://schickling.me/rust-beanstalkd).
+More documentation can be found [here](https://docs.rs/beanstalkd).
 
 ## Usage
 


### PR DESCRIPTION
This changes the doc link to docs.rs as that's always up-to-date with the most recent release