### PR TITLE
Remove extra "License" section

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,10 +65,6 @@ fn main() {
 
 ## License
 
-[MIT License](http://opensource.org/licenses/MIT)
-
-## License
-
 Licensed under either of
 
  * Apache License, Version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)


### PR DESCRIPTION
There was both the dual and single license ones, and we really only need one