### PR TITLE
Add some missing protocol commands

### DIFF
--- a/examples/bury.rs
+++ b/examples/bury.rs
@@ -1,0 +1,10 @@
+extern crate beanstalkd;
+
+use beanstalkd::Beanstalkd;
+
+fn main() {
+    let mut beanstalkd = Beanstalkd::localhost().unwrap();
+    let (id, body) = beanstalkd.reserve().unwrap();
+    println!("{}", body);
+    let _ = beanstalkd.bury(id, 1024).unwrap();
+}

--- a/examples/release.rs
+++ b/examples/release.rs
@@ -1,0 +1,10 @@
+extern crate beanstalkd;
+
+use beanstalkd::Beanstalkd;
+
+fn main() {
+    let mut beanstalkd = Beanstalkd::localhost().unwrap();
+    let (id, body) = beanstalkd.reserve().unwrap();
+    println!("{}", body);
+    let _ = beanstalkd.release(id, 1024, 10).unwrap();
+}

--- a/examples/reserve_with_timeout.rs
+++ b/examples/reserve_with_timeout.rs
@@ -4,18 +4,10 @@ use beanstalkd::Beanstalkd;
 
 fn main() {
     let mut beanstalkd = Beanstalkd::localhost().unwrap();
-    loop {
-        match beanstalkd.reserve_with_timeout(2) {
-            Ok(Some((id, body))) => {
-                if id > 0 && &body != "TIMED_OUT" {
-                    println!("id: {} body: {}", id, body);
-                    break;
-                } else {
-                    println!("no job, do some other stuff...");
-                }
-            },
-            Ok(None) => println!("timedout"),
-            Err(err) => println!("{}", err),
-        }
+
+    match beanstalkd.reserve_with_timeout(2) {
+        Ok(Some((id, body))) => println!("id: {} body: {}", id, body),
+        Ok(None) => println!("timedout"),
+        Err(err) => println!("{}", err),
     }
 }

--- a/examples/reserve_with_timeout.rs
+++ b/examples/reserve_with_timeout.rs
@@ -1,0 +1,20 @@
+extern crate beanstalkd;
+
+use beanstalkd::Beanstalkd;
+
+fn main() {
+    let mut beanstalkd = Beanstalkd::localhost().unwrap();
+    loop {
+        match beanstalkd.reserve_with_timeout(2) {
+            Ok((id, body)) => {
+                if id > 0 && &body != "TIMED_OUT" {
+                    println!("id: {} body: {}", id, body);
+                    break;
+                } else {
+                    println!("no job, do some other stuff...");
+                }
+            },
+            Err(err) => println!("{}", err),
+        }
+    }
+}

--- a/examples/reserve_with_timeout.rs
+++ b/examples/reserve_with_timeout.rs
@@ -6,7 +6,7 @@ fn main() {
     let mut beanstalkd = Beanstalkd::localhost().unwrap();
     loop {
         match beanstalkd.reserve_with_timeout(2) {
-            Ok((id, body)) => {
+            Ok(Some((id, body))) => {
                 if id > 0 && &body != "TIMED_OUT" {
                     println!("id: {} body: {}", id, body);
                     break;
@@ -14,6 +14,7 @@ fn main() {
                     println!("no job, do some other stuff...");
                 }
             },
+            Ok(None) => println!("timedout"),
             Err(err) => println!("{}", err),
         }
     }

--- a/examples/touch.rs
+++ b/examples/touch.rs
@@ -1,0 +1,10 @@
+extern crate beanstalkd;
+
+use beanstalkd::Beanstalkd;
+
+fn main() {
+    let mut beanstalkd = Beanstalkd::localhost().unwrap();
+    let (id, body) = beanstalkd.reserve().unwrap();
+    println!("{}", body);
+    let _ = beanstalkd.touch(id).unwrap();
+}

--- a/src/beanstalkd.rs
+++ b/src/beanstalkd.rs
@@ -53,6 +53,12 @@ impl Beanstalkd {
         self.cmd(commands::reserve()).map(|r| (parse::id(r.clone()), parse::body(r)))
     }
 
+    /// Get the next message out of the queue with timeout. If the timeout runs out a
+    /// ReserveError is returned
+    pub fn reserve_with_timeout(&mut self, timeout: u64) -> BeanstalkdResult<(u64, String)> {
+        self.cmd(commands::reserve_with_timeout(timeout)).map(|r| (parse::id(r.clone()), parse::body(r)))
+    } 
+
     /// Deletes a message out of the queue
     pub fn delete(&mut self, id: u64) -> BeanstalkdResult<()> {
         self.cmd(commands::delete(id)).map(|_| ())

--- a/src/beanstalkd.rs
+++ b/src/beanstalkd.rs
@@ -75,6 +75,10 @@ impl Beanstalkd {
         self.cmd(commands::release(id, priority, delay)).map(|_| ())
     }
 
+    pub fn bury(&mut self, id: u64, priority: u32) -> BeanstalkdResult<()> {
+        self.cmd(commands::bury(id, priority)).map(|_| ())
+    }
+
     /// Returns all available stats
     pub fn stats(&mut self) -> BeanstalkdResult<HashMap<String, String>> {
         self.cmd(commands::stats()).map(parse::hashmap)

--- a/src/beanstalkd.rs
+++ b/src/beanstalkd.rs
@@ -8,7 +8,7 @@ use commands;
 use error::{BeanstalkdError, BeanstalkdResult};
 use parse;
 use request::Request;
-use response::Response;
+use response::{Response};
 
 macro_rules! try {
     ($e:expr) => (match $e { Ok(e) => e, Err(_) => return Err(BeanstalkdError::ConnectionError) })
@@ -53,10 +53,18 @@ impl Beanstalkd {
         self.cmd(commands::reserve()).map(|r| (parse::id(r.clone()), parse::body(r)))
     }
 
-    /// Get the next message out of the queue with timeout. If the timeout runs out a
-    /// id: 0 and body: TIMED_OUT is returned.
-    pub fn reserve_with_timeout(&mut self, timeout: u64) -> BeanstalkdResult<(u64, String)> {
-        self.cmd(commands::reserve_with_timeout(timeout)).map(|r| (parse::id(r.clone()), parse::body(r)))
+    /// Get the next message out of the queue with timeout. If the timeout runs out a None is returned
+    /// in BeanstalkdResult.
+    pub fn reserve_with_timeout(&mut self, timeout: u64) -> BeanstalkdResult<Option<(u64, String)>> {
+        self.cmd(commands::reserve_with_timeout(timeout))
+            .map(|r| (parse::id(r.clone()), parse::body(r)))
+            .map(|(id, body)| {
+                if id == 0 {
+                    None
+                } else {
+                    Some((id, body))
+                }
+        })
     } 
 
     /// Deletes a message out of the queue

--- a/src/beanstalkd.rs
+++ b/src/beanstalkd.rs
@@ -71,14 +71,17 @@ impl Beanstalkd {
         self.cmd(commands::delete(id)).map(|_| ())
     }
 
+    /// Release a job in the queue
     pub fn release(&mut self, id: u64, priority: u32, delay: u32) -> BeanstalkdResult<()> {
         self.cmd(commands::release(id, priority, delay)).map(|_| ())
     }
 
+    /// Bury a job in the queue
     pub fn bury(&mut self, id: u64, priority: u32) -> BeanstalkdResult<()> {
         self.cmd(commands::bury(id, priority)).map(|_| ())
     }
 
+    /// Touch a job in the queue
     pub fn touch(&mut self, id: u64) -> BeanstalkdResult<()> {
         self.cmd(commands::touch(id)).map(|_| ())
     }

--- a/src/beanstalkd.rs
+++ b/src/beanstalkd.rs
@@ -71,6 +71,10 @@ impl Beanstalkd {
         self.cmd(commands::delete(id)).map(|_| ())
     }
 
+    pub fn release(&mut self, id: u64, priority: u32, delay: u32) -> BeanstalkdResult<()> {
+        self.cmd(commands::release(id, priority, delay)).map(|_| ())
+    }
+
     /// Returns all available stats
     pub fn stats(&mut self) -> BeanstalkdResult<HashMap<String, String>> {
         self.cmd(commands::stats()).map(parse::hashmap)

--- a/src/beanstalkd.rs
+++ b/src/beanstalkd.rs
@@ -54,7 +54,7 @@ impl Beanstalkd {
     }
 
     /// Get the next message out of the queue with timeout. If the timeout runs out a
-    /// ReserveError is returned
+    /// id: 0 and body: TIMED_OUT is returned.
     pub fn reserve_with_timeout(&mut self, timeout: u64) -> BeanstalkdResult<(u64, String)> {
         self.cmd(commands::reserve_with_timeout(timeout)).map(|r| (parse::id(r.clone()), parse::body(r)))
     } 

--- a/src/beanstalkd.rs
+++ b/src/beanstalkd.rs
@@ -79,6 +79,10 @@ impl Beanstalkd {
         self.cmd(commands::bury(id, priority)).map(|_| ())
     }
 
+    pub fn touch(&mut self, id: u64) -> BeanstalkdResult<()> {
+        self.cmd(commands::touch(id)).map(|_| ())
+    }
+
     /// Returns all available stats
     pub fn stats(&mut self) -> BeanstalkdResult<HashMap<String, String>> {
         self.cmd(commands::stats()).map(parse::hashmap)

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -20,6 +20,10 @@ pub fn delete(id: u64) -> String {
     build("delete", vec![id.to_string()], "")
 }
 
+pub fn release(id: u64, priority: u32, delay: u32) -> String {
+    build("release", vec![id.to_string(), priority.to_string(), delay.to_string()], "")
+}
+
 pub fn stats() -> String {
     build("stats", vec![], "")
 }
@@ -74,6 +78,11 @@ fn reserve_with_timeout_test() {
 #[test]
 fn delete_test() {
     assert_eq!(delete(1), "delete 1\r\n".to_string());
+}
+
+#[test]
+fn release_test() {
+    assert_eq!(release(1, 1024, 10), "release 1 1024 10\r\n".to_string());
 }
 
 #[test]

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -24,6 +24,10 @@ pub fn release(id: u64, priority: u32, delay: u32) -> String {
     build("release", vec![id.to_string(), priority.to_string(), delay.to_string()], "")
 }
 
+pub fn bury(id: u64, priority: u32) -> String {
+    build("bury", vec![id.to_string(), priority.to_string()], "")
+}
+
 pub fn stats() -> String {
     build("stats", vec![], "")
 }
@@ -83,6 +87,11 @@ fn delete_test() {
 #[test]
 fn release_test() {
     assert_eq!(release(1, 1024, 10), "release 1 1024 10\r\n".to_string());
+}
+
+#[test]
+fn bury_test() {
+    assert_eq!(bury(1, 1024), "bury 1 1024\r\n".to_string());
 }
 
 #[test]

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -12,6 +12,10 @@ pub fn reserve() -> String {
     build("reserve", vec![], "")
 }
 
+pub fn reserve_with_timeout(timeout: u64) -> String {
+    build("reserve-with-timeout", vec![timeout.to_string()], "")
+}
+
 pub fn delete(id: u64) -> String {
     build("delete", vec![id.to_string()], "")
 }
@@ -60,6 +64,11 @@ fn put_test() {
 #[test]
 fn reserve_test() {
     assert_eq!(reserve(), "reserve\r\n".to_string());
+}
+
+#[test]
+fn reserve_with_timeout_test() {
+    assert_eq!(reserve_with_timeout(10), "reserve-with-timeout 10\r\n".to_string())
 }
 
 #[test]

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -28,6 +28,10 @@ pub fn bury(id: u64, priority: u32) -> String {
     build("bury", vec![id.to_string(), priority.to_string()], "")
 }
 
+pub fn touch(id: u64) -> String {
+    build("touch", vec![id.to_string()], "")
+}
+
 pub fn stats() -> String {
     build("stats", vec![], "")
 }
@@ -92,6 +96,11 @@ fn release_test() {
 #[test]
 fn bury_test() {
     assert_eq!(bury(1, 1024), "bury 1 1024\r\n".to_string());
+}
+
+#[test]
+fn touch_test() {
+    assert_eq!(touch(1), "touch 1\r\n".to_string());
 }
 
 #[test]

--- a/src/request.rs
+++ b/src/request.rs
@@ -50,13 +50,6 @@ impl<'a> Request<'a> {
         };
         let mut data = line.clone();
 
-        if status == Status::TIMED_OUT {
-            return Ok(Response {
-                status: status,
-                data: "".to_owned(),
-            })
-        }
-
         if status == Status::OK || status == Status::RESERVED {
             let segment_offset = match status {
                 Status::OK => 1,

--- a/src/request.rs
+++ b/src/request.rs
@@ -43,6 +43,7 @@ impl<'a> Request<'a> {
             "WATCHING" => Status::WATCHING,
             "NOT_IGNORED" => Status::NOT_IGNORED,
             "TIMED_OUT" => Status::TIMED_OUT,
+            "RELEASED" => Status::RELEASED,
             _ => return Err(BeanstalkdError::RequestError),
         };
         let mut data = line.clone();

--- a/src/request.rs
+++ b/src/request.rs
@@ -45,6 +45,7 @@ impl<'a> Request<'a> {
             "TIMED_OUT" => Status::TIMED_OUT,
             "RELEASED" => Status::RELEASED,
             "BURIED" => Status::BURIED,
+            "TOUCHED" => Status::TOUCHED,
             _ => return Err(BeanstalkdError::RequestError),
         };
         let mut data = line.clone();

--- a/src/request.rs
+++ b/src/request.rs
@@ -50,7 +50,7 @@ impl<'a> Request<'a> {
         if status == Status::TIMED_OUT {
             return Ok(Response {
                 status: status,
-                data: String::from("TIMED_OUT 0 9\r\nTIMED_OUT\r\n"),
+                data: "".to_owned(),
             })
         }
 

--- a/src/request.rs
+++ b/src/request.rs
@@ -44,6 +44,7 @@ impl<'a> Request<'a> {
             "NOT_IGNORED" => Status::NOT_IGNORED,
             "TIMED_OUT" => Status::TIMED_OUT,
             "RELEASED" => Status::RELEASED,
+            "BURIED" => Status::BURIED,
             _ => return Err(BeanstalkdError::RequestError),
         };
         let mut data = line.clone();

--- a/src/request.rs
+++ b/src/request.rs
@@ -42,9 +42,17 @@ impl<'a> Request<'a> {
             "DELETED" => Status::DELETED,
             "WATCHING" => Status::WATCHING,
             "NOT_IGNORED" => Status::NOT_IGNORED,
+            "TIMED_OUT" => Status::TIMED_OUT,
             _ => return Err(BeanstalkdError::RequestError),
         };
         let mut data = line.clone();
+
+        if status == Status::TIMED_OUT {
+            return Ok(Response {
+                status: status,
+                data: String::from("TIMED_OUT 0 9\r\nTIMED_OUT\r\n"),
+            })
+        }
 
         if status == Status::OK || status == Status::RESERVED {
             let segment_offset = match status {

--- a/src/response.rs
+++ b/src/response.rs
@@ -9,6 +9,7 @@ pub enum Status {
     WATCHING,
     NOT_IGNORED,
     TIMED_OUT,
+    RELEASED,
 }
 
 #[derive(Clone)]

--- a/src/response.rs
+++ b/src/response.rs
@@ -10,6 +10,7 @@ pub enum Status {
     NOT_IGNORED,
     TIMED_OUT,
     RELEASED,
+    BURIED,
 }
 
 #[derive(Clone)]

--- a/src/response.rs
+++ b/src/response.rs
@@ -8,6 +8,7 @@ pub enum Status {
     DELETED,
     WATCHING,
     NOT_IGNORED,
+    TIMED_OUT,
 }
 
 #[derive(Clone)]

--- a/src/response.rs
+++ b/src/response.rs
@@ -11,6 +11,7 @@ pub enum Status {
     TIMED_OUT,
     RELEASED,
     BURIED,
+    TOUCHED,
 }
 
 #[derive(Clone)]


### PR DESCRIPTION
I added some missing protocol commands:
* reserve with timeout
* bury
* touch
* release

All changes I made are backwards compatible.

I added also an example for any new feature and completed the test as you did @schickling.
It would be awesome if you can review my pull request and merge it. 
If you merge it and release a new version on crates.io I'll drive the library to completion. There are more protocol commands that are not implemented yet.

If you've any suggestion, feel free to contact me. 